### PR TITLE
feature-request: add custom value for bg-size

### DIFF
--- a/octoprint_custombackground/__init__.py
+++ b/octoprint_custombackground/__init__.py
@@ -16,7 +16,7 @@ class custombackground(octoprint.plugin.AssetPlugin,
 
 	##-- Settings mixin
 	def get_settings_defaults(self):
-		return dict(background_url="/static/img/graph-background.png", icon_url="/static/img/tentacle-20x20.png", fillMethod="cover", position="center center", uploaded_url="", axes_text_color="", tick_color="", temp_line_colors="")
+		return dict(background_url="/static/img/graph-background.png", icon_url="/static/img/tentacle-20x20.png", fillMethod="cover", position="center center", uploaded_url="", axes_text_color="", tick_color="", temp_line_colors="", customFillSize="50%")
 
 	def get_settings_version(self):
 		return 1

--- a/octoprint_custombackground/static/js/custombackground.js
+++ b/octoprint_custombackground/static/js/custombackground.js
@@ -9,13 +9,13 @@ $(function() {
 		self.icon_url = ko.observable();
 		self.fillMethod = ko.observable();
 		self.fillOptions = ko.observableArray([{
-						name : 'auto',
+						name : 'Auto',
 						value : 'auto'
 					}, {
-						name : 'cover',
+						name : 'Cover',
 						value : 'cover'
 					}, {
-						name : 'contain',
+						name : 'Contain',
 						value : 'contain'
 					}, {
 						name : 'Custom Value',

--- a/octoprint_custombackground/static/js/custombackground.js
+++ b/octoprint_custombackground/static/js/custombackground.js
@@ -17,9 +17,13 @@ $(function() {
 					}, {
 						name : 'contain',
 						value : 'contain'
+					}, {
+						name : 'Custom Value',
+						value : 'custom'
 					}
 				]);
 		self.position = ko.observable();
+		self.customFillSize = ko.observable();
 		self.selectedBundledImage = ko.observable('')
 
 		self.onBeforeBinding = function() {
@@ -45,10 +49,15 @@ $(function() {
 			self.icon_url(self.settings.settings.plugins.custombackground.icon_url());
 			self.fillMethod(self.settings.settings.plugins.custombackground.fillMethod());
 			self.position(self.settings.settings.plugins.custombackground.position());
+			self.customFillSize(self.settings.settings.plugins.custombackground.customFillSize());
 		}
 
 		self.onAfterBinding = function() {
-			$("#temperature-graph").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.background_url() + "')","background-size":self.settings.settings.plugins.custombackground.fillMethod(),"background-position":self.settings.settings.plugins.custombackground.position()});
+			var fillSize = self.settings.settings.plugins.custombackground.fillMethod();
+			if (fillSize === 'custom') {
+				fillSize = self.settings.settings.plugins.custombackground.customFillSize() || '50%';
+			}
+			$("#temperature-graph").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.background_url() + "')","background-size":fillSize,"background-position":self.settings.settings.plugins.custombackground.position()});
 			$("#navbar .navbar-inner .brand span").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.icon_url() + "')"});
 		}
 
@@ -63,6 +72,7 @@ $(function() {
 		self.onEventSettingsUpdated = function (payload) {
 			self.background_url(self.settings.settings.plugins.custombackground.background_url());
 			self.icon_url(self.settings.settings.plugins.custombackground.icon_url());
+			self.customFillSize(self.settings.settings.plugins.custombackground.customFillSize());
 			self.bundledImages = ko.observableArray([{
 							name : 'OctoPrint',
 							path : '/static/img/graph-background.png'
@@ -81,7 +91,11 @@ $(function() {
 						}
 					]);
 
-			$("#temperature-graph").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.background_url() + "')","background-size":self.settings.settings.plugins.custombackground.fillMethod(),"background-position":self.settings.settings.plugins.custombackground.position()});
+			var fillSize = self.settings.settings.plugins.custombackground.fillMethod();
+			if (fillSize === 'custom') {
+				fillSize = self.settings.settings.plugins.custombackground.customFillSize() || '50%';
+			}
+			$("#temperature-graph").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.background_url() + "')","background-size":fillSize,"background-position":self.settings.settings.plugins.custombackground.position()});
 			$("#navbar .navbar-inner .brand span").css({"background-image":"url('" + window.location.pathname.replace(/\/$/, '') + self.settings.settings.plugins.custombackground.icon_url() + "')"});
 		}
 

--- a/octoprint_custombackground/templates/custombackground_settings.jinja2
+++ b/octoprint_custombackground/templates/custombackground_settings.jinja2
@@ -14,6 +14,13 @@
 			<select data-bind="options: fillOptions,optionsText: 'name',optionsValue: 'value',value: settings.settings.plugins.custombackground.fillMethod"></select>
 		</div>
 	</div>
+	<div class="control-group" data-bind="visible: settings.settings.plugins.custombackground.fillMethod() === 'custom'">
+		<label class="control-label">{{ _('Custom Fill Size') }}</label>
+		<div class="controls">
+			<input type="text" class="input-block" placeholder="e.g., 50%, 100px, auto" data-bind="value: settings.settings.plugins.custombackground.customFillSize">
+			<small>{{ _('Enter a valid CSS background-size value like 50%% or 100px or auto') }}</small>
+		</div>
+	</div>
 	<div class="control-group">
 		<label class="control-label">{{ _('Background Position') }} <a href="https://www.w3schools.com/cssref/pr_background-position.asp" title="CSS Background Position Specification" target="_blank" style="text-decoration: none;"><i class="icon icon-info-sign"></i></a></label>
 		<div class="controls">


### PR DESCRIPTION
This PR adds a menu selection to "Image Fill Method" that allows for a custom value to be supplied to `background-size`. See [support-repo](https://github.com/jhauga/support-repo/tree/octoprint-plgin-cstmImgFll) for GIF animation from `OctoPrint` Development mode test, and **smoke and mirror** GitHub page where functionality is condensed.

Edit: Below is an animation of using the feature when it was tested using `OctoPrint` development mode.

![demo.gif](https://github.com/jhauga/support-repo/blob/octoprint-plgin-cstmImgFll/demo.gif?raw=true)
